### PR TITLE
feat: add Firefox support via webextension-polyfill

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,29 @@
+---
+name: security-reviewer
+description: Security review focused on Chrome Extension attack surface — message passing, content script isolation, CSP, and manifest permissions
+---
+
+Review the Chrome extension code for security issues specific to Manifest V3. Focus on these areas:
+
+**1. Message passing** (`chrome.runtime.onMessage`)
+- Verify that message handlers in `src/content/content.ts` validate the `sender` argument before processing.
+- Confirm that responses never reflect untrusted tab-sourced data (URLs, titles, element text) directly back into innerHTML.
+
+**2. Content script isolation**
+- `src/content/content.ts` runs in the page's context — flag any location where DOM data (e.g., `element.src`, `element.href`, `document.title`) is written to the DOM without sanitization.
+- Check that `analyzeAccessibility`, `analyzeSEO`, and `analyzePerformance` only *read* the DOM and never write back to it.
+
+**3. Manifest permissions** (`src/manifest.json`)
+- Flag any host permissions broader than needed (e.g., `<all_urls>` vs. specific origins).
+- Verify `content_scripts` `matches` patterns are as narrow as the extension requires.
+- Check that only APIs actually used are listed under `permissions`.
+
+**4. Content Security Policy**
+- Verify `content_security_policy` in the manifest blocks inline scripts (`'unsafe-inline'` absent) and restricts `script-src` to `'self'`.
+- Confirm no remote script sources are allowed.
+
+**5. Data export path**
+- Confirm `exportResults` in `src/popup/popup.ts` writes analysis data only to a local `Blob` → object URL → anchor download, and never POSTs to an external endpoint.
+
+**Output format**
+List each finding with: severity (high/medium/low), file + line, description, and a one-line fix recommendation. If no issues are found in a category, note it as "clean".

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsc --noEmit 2>&1 | head -20"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"import os,sys,json; d=json.loads(os.environ.get('CLAUDE_TOOL_INPUT','{}')); f=d.get('file_path',''); sys.stdout.write('ERROR: Do not edit dist/ directly — run npm run build instead\\n') or sys.exit(2) if '/dist/' in f else sys.exit(0)\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/gen-test/SKILL.md
+++ b/.claude/skills/gen-test/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: gen-test
+description: Generate Jest unit tests for a WebQualityAnalyzer source file following project conventions (listener capture, jsdom quirks, isolateModules)
+---
+
+Generate Jest tests for the file: $ARGUMENTS
+
+Follow these project-specific conventions from CLAUDE.md:
+
+**Module load-time side effects**
+- `background.ts`: use `jest.isolateModules` + `require()` to get a fresh execution per test; capture the registered listener in `beforeAll` before any `jest.clearAllMocks()` in `beforeEach` wipes it. Suppress lint with `// eslint-disable-next-line @typescript-eslint/no-require-imports`.
+- `content.ts`: capture the `chrome.runtime.onMessage` listener in `beforeAll` before `beforeEach` clears mocks.
+
+**DOM setup**
+- Always use `document.createElement` + `appendChild` — never assign test DOM via `innerHTML` string assignment (blocked by PreToolUse hook).
+- After setting `document.head.innerHTML`, always set `document.title` *afterwards* (jsdom removes the `<title>` element on innerHTML reassignment).
+
+**jsdom quirks**
+- `img.naturalWidth` / `img.naturalHeight` are always `0` — use `Object.defineProperty` with a getter to simulate large images.
+- `Blob.prototype.text()` is not implemented — spy on `JSON.stringify` to inspect data passed to the Blob constructor, or read the blob with `FileReader` in an async test.
+- `URL.createObjectURL` / `URL.revokeObjectURL` are not implemented — mock both on `global.URL` before testing `exportResults`.
+
+**"Perfect Score!" condition**
+- `displayCategoryContent` shows it only when `issues.length === 0 && suggestions.length === 0`.
+- Performance generic suggestions are only emitted when `score < 100`, so all three tabs can reach this state.
+
+**Coverage target**
+- After generating, run `npx jest tests/unit/<file>.test.ts --coverage` and verify all metrics are ≥ 80%.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Claude Code auto-memory (local only)
+# Claude Code — local-only files (do not commit)
 memory/
+.claude/settings.local.json
+.claude/*.local.md
 
 # Logs
 logs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run build        # Compile TypeScript and bundle via Webpack → dist/
-npm run dev          # Watch mode — rebuilds on file changes
-npm test             # Run Jest test suite
-npm run test:watch   # Jest in watch mode
-npm run lint         # ESLint on src/ and tests/
+npm run build          # Compile TypeScript and bundle for both browsers → dist/chrome/ and dist/firefox/
+npm run build:chrome   # Chrome only
+npm run build:firefox  # Firefox only
+npm run dev            # Watch mode (Chrome)
+npm run dev:firefox    # Watch mode (Firefox)
+npm test               # Run Jest test suite
+npm run test:watch     # Jest in watch mode
+npm run lint           # ESLint on src/ and tests/
 ```
 
 To run a single test file:
@@ -19,17 +22,18 @@ npx jest tests/unit/content.test.ts
 
 ## Architecture
 
-WebQualityAnalyzer is a **Chrome Manifest V3 browser extension** with three isolated execution contexts, each compiled to a separate Webpack bundle:
+WebQualityAnalyzer is a **Chrome and Firefox Manifest V3 browser extension** with three isolated execution contexts, each compiled to a separate Webpack bundle:
 
 | Script | Bundle | Role |
 |--------|--------|------|
-| `src/background/background.ts` | `background.bundle.js` | Service worker — extension lifecycle events |
+| `src/background/background.ts` | `background.bundle.js` | Extension lifecycle events |
 | `src/content/content.ts` | `content.bundle.js` | Content script — runs analysis directly on page DOM |
 | `src/popup/popup.ts` | `popup.bundle.js` | Popup UI — sends messages to content script, renders results |
+| `src/shared/browser.ts` | (imported by all) | Re-exports `webextension-polyfill` as `browser.*` |
 
 ### Communication Flow
 
-Popup → (Chrome message API) → Content Script → returns `AnalysisResult` → Popup renders
+Popup → (`browser.tabs.sendMessage`) → Content Script → returns `AnalysisResult` → Popup renders
 
 The content script exposes three analysis functions (`analyzeAccessibility`, `analyzeSEO`, `analyzePerformance`) that return `CategoryResult` objects with a numeric score (0–100) and arrays of `Issue` items.
 
@@ -68,7 +72,16 @@ Other bundles consume them with zero runtime cost via `import type { AnalysisRes
 
 ### Build Output
 
-Webpack copies `src/manifest.json` and `src/popup.html` into `dist/` alongside the bundles. The `dist/` directory is what gets loaded as the unpacked extension in Chrome.
+Webpack accepts `--env browser=chrome|firefox` and outputs to `dist/<browser>/`. The correct manifest (`src/manifest.chrome.json` or `src/manifest.firefox.json`) and `src/popup.html` are copied alongside the bundles.
+
+- `dist/chrome/` — load via `chrome://extensions` → Load unpacked
+- `dist/firefox/` — load via `about:debugging` → Load Temporary Add-on → select `manifest.json`
+
+### Browser API
+
+All extension API calls use `browser.*` imported from `src/shared/browser.ts`, which re-exports `webextension-polyfill`. This provides a unified Promise-based API across Chrome and Firefox — no `chrome.*` calls appear in source files directly.
+
+The `onMessage` listener in `content.ts` returns a `Promise` (polyfill pattern) rather than using the `sendResponse` callback.
 
 ## Code Quality
 
@@ -92,19 +105,22 @@ Actions are pinned to commit SHAs for supply-chain security. Dependabot is confi
 
 | File | What it covers |
 |------|----------------|
-| `tests/unit/content.test.ts` | `analyzeAccessibility`, `analyzeSEO`, `analyzePerformance`, `performQualityAnalysis`, `chrome.runtime.onMessage` listener |
+| `tests/unit/content.test.ts` | `analyzeAccessibility`, `analyzeSEO`, `analyzePerformance`, `performQualityAnalysis`, `browser.runtime.onMessage` listener |
 | `tests/unit/popup.test.ts` | All exported popup UI functions: `switchTab`, `updatePageInfo`, `showLoadingState`, `showError`, `displayResults`, `displayCategoryContent`, `getScoreColor`, `exportResults`, `runAnalysis` |
-| `tests/unit/background.test.ts` | `chrome.runtime.onInstalled` registration and callback |
+| `tests/unit/background.test.ts` | `browser.runtime.onInstalled` registration and callback |
 
 Coverage baseline (2026-03): **94.69% stmts / 90.81% branches / 86.48% funcs / 94.58% lines** — all above the 80% global threshold.
 
 ### Setup
+
+`webextension-polyfill` is intercepted in tests via `moduleNameMapper` in `jest.config.ts`, which redirects it to `tests/__mocks__/webextension-polyfill.ts`. That stub re-exports the global `chrome` mock, so `browser.*` calls in source files resolve to the same `jest.fn()` stubs.
 
 Chrome extension APIs (`chrome.*`) are mocked globally in `tests/setup.ts` (loaded via `setupFilesAfterEnv`). All `chrome.runtime` and `chrome.tabs` methods are `jest.fn()` so any module that calls them at import time won't throw in jsdom.
 
 ### Key patterns
 
 - **Module load-time side effects** (background.ts, content.ts): capture the registered listener in `beforeAll` before any `jest.clearAllMocks()` in `beforeEach` wipes it. For background.ts use `jest.isolateModules` + `require()` to get a fresh execution per test — suppress the lint rule with `// eslint-disable-next-line @typescript-eslint/no-require-imports` on that line.
+- **onMessage listener signature**: the listener returns `Promise.resolve(performQualityAnalysis())` for the `analyze` action and `undefined` otherwise — test it by awaiting the return value, not by checking a `sendResponse` callback.
 - **"Perfect Score!" condition**: `displayCategoryContent` shows it only when `issues.length === 0 && suggestions.length === 0`. Performance generic suggestions are only emitted when `score < 100`, so all three category tabs can reach this state.
 - **Security hook in tests**: a `PreToolUse:Edit` hook rejects edits that set DOM content via direct HTML string assignment. Use `document.createElement` + `appendChild` when adding test DOM nodes instead.
 - **jsdom quirks**:
@@ -112,3 +128,4 @@ Chrome extension APIs (`chrome.*`) are mocked globally in `tests/setup.ts` (load
   - `img.naturalWidth` / `img.naturalHeight` are always `0` — use `Object.defineProperty` with a getter to simulate large images.
   - `Blob.prototype.text()` is not implemented — spy on `JSON.stringify` to inspect data passed to the Blob constructor.
   - `URL.createObjectURL` / `URL.revokeObjectURL` are not implemented — mock both on `global.URL` before testing `exportResults`.
+  - `element.style.background` is normalized to `rgb()` — use `element.getAttribute('style')` to assert raw hex values set via inline styles.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Adrian Jiga
+Copyright (c) 2026 Adrian Jiga
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WebQualityAnalyzer
+# Web Quality Analyzer
 
-A Chrome Manifest V3 browser extension that audits web pages for accessibility, SEO, and performance issues and gives an instant quality score.
+A Chrome and Firefox Manifest V3 browser extension that audits web pages for accessibility, SEO, and performance issues and gives an instant quality score.
 
 [![CI](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/ci.yml/badge.svg)](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/ci.yml)
 [![Tests](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/tests.yml/badge.svg)](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/tests.yml)
@@ -19,19 +19,31 @@ A Chrome Manifest V3 browser extension that audits web pages for accessibility, 
 **Prerequisites:** Node.js 20 LTS or later, npm
 
 ```bash
-npm install       # install dependencies
-npm run build     # compile TypeScript + bundle via Webpack → dist/
-npm run dev       # watch mode — rebuilds on file changes
-npm run lint      # ESLint
-npm test          # Jest test suite (with coverage)
+npm install          # install dependencies
+npm run build        # compile + bundle for both Chrome and Firefox → dist/chrome/ and dist/firefox/
+npm run build:chrome # build Chrome only
+npm run build:firefox # build Firefox only
+npm run dev          # watch mode (Chrome)
+npm run dev:firefox  # watch mode (Firefox)
+npm run lint         # ESLint
+npm test             # Jest test suite (with coverage)
 ```
 
-## Loading the extension in Chrome
+## Loading the extension
 
-1. Run `npm run build` to populate `dist/`
+### Chrome
+
+1. Run `npm run build:chrome`
 2. Open `chrome://extensions`
 3. Enable **Developer mode**
-4. Click **Load unpacked** and select the `dist/` directory
+4. Click **Load unpacked** and select `dist/chrome/`
+
+### Firefox
+
+1. Run `npm run build:firefox`
+2. Open `about:debugging` → **This Firefox**
+3. Click **Load Temporary Add-on...**
+4. Select `dist/firefox/manifest.json`
 
 ## Running tests
 
@@ -41,22 +53,32 @@ npm run test:watch                    # watch mode
 npx jest tests/unit/content.test.ts  # single file
 ```
 
-Coverage thresholds (all enforced): **80% statements, branches, functions, and lines**.  
+Coverage thresholds (all enforced): **80% statements, branches, functions, and lines**.
 Current baseline: 94.69% stmts / 90.81% branches / 86.48% funcs / 94.58% lines.
 
 ## Architecture
 
-The extension has three isolated execution contexts, each compiled to a separate Webpack bundle:
+The extension has three isolated execution contexts, each compiled to a separate Webpack bundle, plus a shared browser API abstraction:
 
-| Script | Bundle | Role |
+| Source | Bundle | Role |
 |--------|--------|------|
-| `src/background/background.ts` | `background.bundle.js` | Service worker — extension lifecycle |
+| `src/background/background.ts` | `background.bundle.js` | Extension lifecycle events |
 | `src/content/content.ts` | `content.bundle.js` | Runs analysis directly on the page DOM |
 | `src/popup/popup.ts` | `popup.bundle.js` | Popup UI — sends messages to content script, renders results |
+| `src/shared/browser.ts` | (imported by all) | Re-exports `webextension-polyfill` for unified `browser.*` API |
 
-**Communication flow:** Popup → Chrome message API → Content Script → `AnalysisResult` → Popup renders
+**Communication flow:** Popup → `browser.tabs.sendMessage` → Content Script → `AnalysisResult` → Popup renders
 
 Shared types (`AnalysisResult`, `CategoryResult`, `Issue`) are exported from `content.ts` and consumed via `import type` in `popup.ts` — erased before bundling, zero runtime overhead.
+
+### Browser manifests
+
+| File | Target | Notes |
+|------|--------|-------|
+| `src/manifest.chrome.json` | Chrome | MV3, `background.service_worker` |
+| `src/manifest.firefox.json` | Firefox | MV3, `background.scripts`, `browser_specific_settings.gecko` (min Firefox 109) |
+
+Webpack selects the correct manifest via `--env browser=chrome|firefox` and writes the build to `dist/chrome/` or `dist/firefox/`.
 
 ## CI
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,9 @@ const config: Config = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
+  moduleNameMapper: {
+    'webextension-polyfill': '<rootDir>/tests/__mocks__/webextension-polyfill.ts',
+  },
   collectCoverageFrom: [
     "src/**/*.ts",
     "!src/**/*.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@types/chrome": "^0.1.38",
         "@types/jest": "^30.0.0",
+        "@types/webextension-polyfill": "^0.12.5",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
         "babel-loader": "^10.1.1",
@@ -26,6 +27,7 @@
         "ts-jest": "^29.4.6",
         "ts-loader": "^9.5.4",
         "typescript": "^5.9.3",
+        "webextension-polyfill": "^0.12.0",
         "webpack": "^5.105.4",
         "webpack-cli": "^7.0.2"
       }
@@ -2999,6 +3001,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.5.tgz",
+      "integrity": "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8734,6 +8743,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
+      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
+      "dev": true,
+      "license": "MPL-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "description": "Web quality analysis browser extension for developers and QA professionals",
   "scripts": {
-    "build": "webpack",
-    "dev": "webpack --watch",
+    "build": "webpack --env browser=chrome && webpack --env browser=firefox",
+    "build:chrome": "webpack --env browser=chrome",
+    "build:firefox": "webpack --env browser=firefox",
+    "dev": "webpack --watch --env browser=chrome",
+    "dev:chrome": "webpack --watch --env browser=chrome",
+    "dev:firefox": "webpack --watch --env browser=firefox",
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint src tests"
@@ -16,6 +20,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@types/chrome": "^0.1.38",
     "@types/jest": "^30.0.0",
+    "@types/webextension-polyfill": "^0.12.5",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
     "babel-loader": "^10.1.1",
@@ -28,6 +33,7 @@
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.4",
     "typescript": "^5.9.3",
+    "webextension-polyfill": "^0.12.0",
     "webpack": "^5.105.4",
     "webpack-cli": "^7.0.2"
   }

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,4 +1,5 @@
 // Background script for WebQualityAnalyzer extension
+import { browser } from '../shared/browser';
 
 // Listen for extension installation
-chrome.runtime.onInstalled.addListener((): void => {});
+browser.runtime.onInstalled.addListener((): void => {});

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,4 +1,5 @@
 // Content script for WebQualityAnalyzer extension
+import { browser } from '../shared/browser';
 
 export interface AnalysisResult {
   score: number;
@@ -28,11 +29,11 @@ export interface Issue {
 }
 
 // Listen for messages from popup
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === 'analyze') {
-    const result = performQualityAnalysis();
-    sendResponse(result);
+browser.runtime.onMessage.addListener((request: unknown) => {
+  if ((request as { action: string }).action === 'analyze') {
+    return Promise.resolve(performQualityAnalysis());
   }
+  return undefined;
 });
 
 export function performQualityAnalysis(): AnalysisResult {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "WebQualityAnalyzer",
+  "version": "1.0.0",
+  "description": "Web quality analysis browser extension for developers and QA professionals",
+  "permissions": ["activeTab", "storage", "tabs"],
+  "background": {
+    "service_worker": "background.bundle.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.bundle.js"]
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "WebQualityAnalyzer"
+  }
+}

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -3,9 +3,15 @@
   "name": "WebQualityAnalyzer",
   "version": "1.0.0",
   "description": "Web quality analysis browser extension for developers and QA professionals",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "webqualityanalyzer@example.com",
+      "strict_min_version": "109.0"
+    }
+  },
   "permissions": ["activeTab", "storage", "tabs"],
   "background": {
-    "service_worker": "background.bundle.js"
+    "scripts": ["background.bundle.js"]
   },
   "content_scripts": [
     {

--- a/src/popup.html
+++ b/src/popup.html
@@ -3,15 +3,25 @@
 <head>
   <meta charset="utf-8">
   <style>
-    body { 
-      width: 450px; 
+    /* Palette: Vercel Geist + Stripe Sail
+       Header:    #0a2540  (Stripe deep navy)
+       Primary:   #0070f3  (Vercel blue)
+       Surface:   #ffffff
+       Body bg:   #f6f9fc  (Stripe light)
+       Border:    #dde3ea
+       Text:      #0a2540 / #697b8f
+       Score good:    #059669  Score ok:  #2563eb
+       Score warn:    #b45309  Score bad: #dc2626
+    */
+    body {
+      width: 450px;
       min-height: 500px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       margin: 0;
-      background: #f8f9fa;
+      background: #f6f9fc;
     }
     .header {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      background: #0a2540;
       color: white;
       padding: 20px;
       text-align: center;
@@ -20,47 +30,46 @@
       margin: 0;
       font-size: 18px;
       font-weight: 600;
+      letter-spacing: -0.01em;
     }
     .controls {
       padding: 20px;
       background: white;
-      border-bottom: 1px solid #e9ecef;
+      border-bottom: 1px solid #dde3ea;
     }
     .btn-group {
       display: flex;
       gap: 10px;
       margin-bottom: 15px;
     }
-    button { 
+    button {
       flex: 1;
-      padding: 12px; 
-      background: #007cba;
+      padding: 12px;
+      background: #0070f3;
       color: white;
       border: none;
       border-radius: 6px;
       cursor: pointer;
       font-weight: 500;
-      transition: all 0.2s;
+      transition: background 0.15s;
     }
     button:hover:not(:disabled) {
-      background: #0056b3;
-      transform: translateY(-1px);
+      background: #005cc5;
     }
     button:disabled {
-      background: #6c757d;
+      background: #a0aec0;
       cursor: not-allowed;
-      transform: none;
     }
     .btn-secondary {
-      background: #6c757d !important;
+      background: #697b8f !important;
     }
     .btn-secondary:hover:not(:disabled) {
-      background: #545b62 !important;
+      background: #546374 !important;
     }
     .tabs {
       display: flex;
       background: white;
-      border-bottom: 1px solid #e9ecef;
+      border-bottom: 1px solid #dde3ea;
     }
     .tab {
       flex: 1;
@@ -70,15 +79,17 @@
       border-bottom: 3px solid transparent;
       font-size: 13px;
       font-weight: 500;
-      transition: all 0.2s;
+      color: #697b8f;
+      transition: color 0.15s, background 0.15s;
     }
     .tab.active {
-      border-bottom-color: #007cba;
-      color: #007cba;
-      background: #f8f9fa;
+      border-bottom-color: #0070f3;
+      color: #0070f3;
+      background: #f6f9fc;
     }
     .tab:hover {
-      background: #f8f9fa;
+      background: #f6f9fc;
+      color: #0a2540;
     }
     .tab-content {
       display: none;
@@ -91,10 +102,9 @@
       display: block;
     }
     .score-card {
-      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
       color: white;
       padding: 20px;
-      border-radius: 10px;
+      border-radius: 8px;
       text-align: center;
       margin-bottom: 20px;
     }
@@ -105,36 +115,33 @@
     }
     .score-label {
       font-size: 14px;
-      opacity: 0.9;
+      opacity: 0.88;
     }
     .metric-card {
       background: white;
-      border: 1px solid #e9ecef;
+      border: 1px solid #dde3ea;
       border-radius: 8px;
       padding: 15px;
       margin-bottom: 10px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
     .metric-header {
       display: flex;
-      justify-content: between;
+      justify-content: space-between;
       align-items: center;
       margin-bottom: 10px;
     }
     .metric-title {
       font-weight: 600;
       font-size: 14px;
+      color: #0a2540;
     }
     .metric-count {
-      background: #dc3545;
       color: white;
-      padding: 2px 8px;
+      padding: 2px 10px;
       border-radius: 12px;
       font-size: 12px;
       font-weight: 500;
-    }
-    .metric-count.success {
-      background: #28a745;
+      white-space: nowrap;
     }
     .issue-list {
       list-style: none;
@@ -144,27 +151,29 @@
     .issue-item {
       padding: 8px 12px;
       margin: 5px 0;
-      background: #f8f9fa;
-      border-left: 4px solid #dc3545;
+      background: #fef2f2;
+      border-left: 3px solid #dc2626;
       border-radius: 4px;
       font-size: 13px;
+      color: #0a2540;
     }
     .suggestion-item {
       padding: 8px 12px;
       margin: 5px 0;
-      background: #e7f3ff;
-      border-left: 4px solid #007cba;
+      background: #eff6ff;
+      border-left: 3px solid #0070f3;
       border-radius: 4px;
       font-size: 13px;
+      color: #0a2540;
     }
     .loading {
       text-align: center;
       padding: 40px;
-      color: #6c757d;
+      color: #697b8f;
     }
     .spinner {
-      border: 3px solid #f3f3f3;
-      border-top: 3px solid #007cba;
+      border: 3px solid #dde3ea;
+      border-top: 3px solid #0070f3;
       border-radius: 50%;
       width: 30px;
       height: 30px;
@@ -178,30 +187,31 @@
     .empty-state {
       text-align: center;
       padding: 40px 20px;
-      color: #6c757d;
+      color: #697b8f;
     }
     .page-info {
-      background: #f8f9fa;
-      padding: 15px;
-      border-radius: 8px;
+      background: #f6f9fc;
+      padding: 12px 15px;
+      border-radius: 6px;
       margin-bottom: 15px;
+      border: 1px solid #dde3ea;
     }
     .page-url {
       font-size: 12px;
-      color: #6c757d;
+      color: #697b8f;
       word-break: break-all;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>🔍 WebQualityAnalyzer</h1>
+    <h1>Web Quality Analyzer</h1>
   </div>
   
   <div class="controls">
     <div class="btn-group">
-      <button id="analyze-btn">🚀 Analyze Page</button>
-      <button id="export-btn" class="btn-secondary" disabled>📊 Export</button>
+      <button id="analyze-btn">Analyze Page</button>
+      <button id="export-btn" class="btn-secondary" disabled>Export</button>
     </div>
     <div class="page-info" id="page-info" style="display: none;">
       <div class="page-url" id="page-url"></div>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -1,5 +1,6 @@
 // Popup script for WebQualityAnalyzer extension
 import type { AnalysisResult, CategoryResult } from '../content/content';
+import { browser } from '../shared/browser';
 
 let currentAnalysis: AnalysisResult | null = null;
 
@@ -42,14 +43,14 @@ export async function runAnalysis(): Promise<void> {
   ) as HTMLButtonElement;
 
   analyzeButton.disabled = true;
-  analyzeButton.innerHTML = '⏳ Analyzing...';
+  analyzeButton.textContent = 'Analyzing...';
   exportButton.disabled = true;
 
   // Show loading state
   showLoadingState();
 
   try {
-    const [tab] = await chrome.tabs.query({
+    const [tab] = await browser.tabs.query({
       active: true,
       currentWindow: true,
     });
@@ -59,9 +60,9 @@ export async function runAnalysis(): Promise<void> {
       updatePageInfo(tab.url);
 
       // Send message to content script
-      const response = await chrome.tabs.sendMessage(tab.id, {
+      const response = await browser.tabs.sendMessage(tab.id, {
         action: 'analyze',
-      });
+      }) as AnalysisResult;
       currentAnalysis = response;
       displayResults(response);
       exportButton.disabled = false;
@@ -70,7 +71,7 @@ export async function runAnalysis(): Promise<void> {
     showError("Could not analyze page. Make sure you're on a valid webpage.");
   } finally {
     analyzeButton.disabled = false;
-    analyzeButton.innerHTML = '🚀 Analyze Page';
+    analyzeButton.textContent = 'Analyze Page';
   }
 }
 
@@ -136,41 +137,35 @@ function displayOverview(result: AnalysisResult): void {
     <div class="metric-card">
       <div class="metric-header">
         <div class="metric-title">🎯 Accessibility</div>
-        <div class="metric-count ${
-          result.categories.accessibility.issues.length === 0 ? 'success' : ''
-        }">
+        <div class="metric-count" style="background: ${getScoreColor(result.categories.accessibility.score)};">
           ${result.categories.accessibility.issues.length} issues
         </div>
       </div>
-      <div style="font-size: 12px; color: #6c757d;">Score: ${
+      <div style="font-size: 12px; color: #697b8f;">Score: ${
         result.categories.accessibility.score
       }/100</div>
     </div>
-    
+
     <div class="metric-card">
       <div class="metric-header">
         <div class="metric-title">🔍 SEO</div>
-        <div class="metric-count ${
-          result.categories.seo.issues.length === 0 ? 'success' : ''
-        }">
+        <div class="metric-count" style="background: ${getScoreColor(result.categories.seo.score)};">
           ${result.categories.seo.issues.length} issues
         </div>
       </div>
-      <div style="font-size: 12px; color: #6c757d;">Score: ${
+      <div style="font-size: 12px; color: #697b8f;">Score: ${
         result.categories.seo.score
       }/100</div>
     </div>
-    
+
     <div class="metric-card">
       <div class="metric-header">
         <div class="metric-title">⚡ Performance</div>
-        <div class="metric-count ${
-          result.categories.performance.issues.length === 0 ? 'success' : ''
-        }">
+        <div class="metric-count" style="background: ${getScoreColor(result.categories.performance.score)};">
           ${result.categories.performance.issues.length} issues
         </div>
       </div>
-      <div style="font-size: 12px; color: #6c757d;">Score: ${
+      <div style="font-size: 12px; color: #697b8f;">Score: ${
         result.categories.performance.score
       }/100</div>
     </div>
@@ -275,10 +270,10 @@ export function displayCategoryContent(
 }
 
 export function getScoreColor(score: number): string {
-  if (score >= 90) return 'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)';
-  if (score >= 80) return 'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)';
-  if (score >= 60) return 'linear-gradient(135deg, #fa709a 0%, #fee140 100%)';
-  return 'linear-gradient(135deg, #ff6b6b 0%, #ee5a24 100%)';
+  if (score >= 90) return '#059669';
+  if (score >= 80) return '#2563eb';
+  if (score >= 60) return '#b45309';
+  return '#dc2626';
 }
 
 export function exportResults(analysis: AnalysisResult): void {

--- a/src/shared/browser.ts
+++ b/src/shared/browser.ts
@@ -1,0 +1,4 @@
+// Provides a unified browser.* API for Chrome and Firefox via webextension-polyfill.
+// Chrome: polyfill wraps chrome.* callbacks as Promises under browser.*
+// Firefox: passes through the native browser.* API unchanged
+export { default as browser } from 'webextension-polyfill';

--- a/tests/__mocks__/webextension-polyfill.ts
+++ b/tests/__mocks__/webextension-polyfill.ts
@@ -1,0 +1,3 @@
+// Jest mock for webextension-polyfill.
+// Maps browser.* to the existing chrome.* global mock so tests don't need changes.
+export default (globalThis as unknown as { chrome: typeof chrome }).chrome;

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -8,9 +8,8 @@ import {
 // ─── Message-listener capture ─────────────────────────────────────────────────
 type MessageListener = (
   request: { action: string },
-  sender: chrome.runtime.MessageSender,
-  sendResponse: (response: unknown) => void
-) => void;
+  sender: chrome.runtime.MessageSender
+) => Promise<unknown> | undefined;
 
 let capturedMessageListener: MessageListener;
 
@@ -943,29 +942,23 @@ describe('Chrome message listener', () => {
     expect(typeof capturedMessageListener).toBe('function');
   });
 
-  it('calls sendResponse with a full AnalysisResult when action is "analyze"', () => {
-    const sendResponse = jest.fn();
-    capturedMessageListener(
+  it('returns a Promise resolving to a full AnalysisResult when action is "analyze"', async () => {
+    const result = capturedMessageListener(
       { action: 'analyze' },
-      {} as chrome.runtime.MessageSender,
-      sendResponse
+      {} as chrome.runtime.MessageSender
     );
-    expect(sendResponse).toHaveBeenCalledTimes(1);
-    const response = sendResponse.mock.calls[0][0] as ReturnType<
-      typeof performQualityAnalysis
-    >;
+    expect(result).toBeInstanceOf(Promise);
+    const response = (await result) as ReturnType<typeof performQualityAnalysis>;
     expect(response).toHaveProperty('score');
     expect(response).toHaveProperty('pageInfo');
     expect(response).toHaveProperty('categories');
   });
 
-  it('does not call sendResponse for unknown action types', () => {
-    const sendResponse = jest.fn();
-    capturedMessageListener(
+  it('returns undefined for unknown action types', () => {
+    const result = capturedMessageListener(
       { action: 'unknown-action' },
-      {} as chrome.runtime.MessageSender,
-      sendResponse
+      {} as chrome.runtime.MessageSender
     );
-    expect(sendResponse).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 });

--- a/tests/unit/popup.test.ts
+++ b/tests/unit/popup.test.ts
@@ -60,31 +60,31 @@ function setupPopupDOM(): void {
 // getScoreColor
 // ══════════════════════════════════════════════════════════════════════════════
 describe('getScoreColor', () => {
-  it('returns a blue gradient for scores >= 90', () => {
-    expect(getScoreColor(90)).toContain('#4facfe');
-    expect(getScoreColor(100)).toContain('#4facfe');
-    expect(getScoreColor(95)).toContain('#4facfe');
+  it('returns emerald green for scores >= 90', () => {
+    expect(getScoreColor(90)).toBe('#059669');
+    expect(getScoreColor(100)).toBe('#059669');
+    expect(getScoreColor(95)).toBe('#059669');
   });
 
-  it('returns a green gradient for scores >= 80 and < 90', () => {
-    expect(getScoreColor(80)).toContain('#43e97b');
-    expect(getScoreColor(89)).toContain('#43e97b');
+  it('returns blue for scores >= 80 and < 90', () => {
+    expect(getScoreColor(80)).toBe('#2563eb');
+    expect(getScoreColor(89)).toBe('#2563eb');
   });
 
-  it('returns a pink/yellow gradient for scores >= 60 and < 80', () => {
-    expect(getScoreColor(60)).toContain('#fa709a');
-    expect(getScoreColor(79)).toContain('#fa709a');
+  it('returns amber for scores >= 60 and < 80', () => {
+    expect(getScoreColor(60)).toBe('#b45309');
+    expect(getScoreColor(79)).toBe('#b45309');
   });
 
-  it('returns a red gradient for scores below 60', () => {
-    expect(getScoreColor(59)).toContain('#ff6b6b');
-    expect(getScoreColor(0)).toContain('#ff6b6b');
-    expect(getScoreColor(1)).toContain('#ff6b6b');
+  it('returns red for scores below 60', () => {
+    expect(getScoreColor(59)).toBe('#dc2626');
+    expect(getScoreColor(0)).toBe('#dc2626');
+    expect(getScoreColor(1)).toBe('#dc2626');
   });
 
-  it('returns a linear-gradient string for every threshold', () => {
+  it('returns a hex color string for every threshold', () => {
     [0, 60, 80, 90, 100].forEach((score) => {
-      expect(getScoreColor(score)).toMatch(/^linear-gradient/);
+      expect(getScoreColor(score)).toMatch(/^#[0-9a-f]{6}$/);
     });
   });
 });
@@ -346,13 +346,13 @@ describe('displayResults', () => {
     expect(document.getElementById('performance-tab')?.textContent?.length).toBeGreaterThan(0);
   });
 
-  it('shows "0 issues" with success styling when a category has no issues', () => {
+  it('shows the green score color on the badge when a category scores 100', () => {
     const result = buildResult();
     result.categories.accessibility = buildCategory(100, [], []);
     displayResults(result);
     const overview = document.getElementById('overview-tab');
-    // The metric-count should have class "success" for 0 issues
-    expect(overview?.querySelector('.metric-count.success')).not.toBeNull();
+    const badge = overview?.querySelector('.metric-count') as HTMLElement | null;
+    expect(badge?.getAttribute('style')).toContain('#059669');
   });
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,54 +5,60 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export default {
-  mode: 'development',
-  entry: {
-    background: './src/background/background.ts',
-    popup: './src/popup/popup.ts',
-    content: './src/content/content.ts',
-  },
-  output: {
-    path: resolve(__dirname, 'dist'),
-    filename: '[name].bundle.js',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        exclude: /node_modules/,
-        use: 'ts-loader',
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env'],
+export default (env) => {
+  const browser = env?.browser ?? 'chrome';
+  const outDir = resolve(__dirname, 'dist', browser);
+  const manifestSrc = `src/manifest.${browser}.json`;
+
+  return {
+    mode: 'development',
+    entry: {
+      background: './src/background/background.ts',
+      popup: './src/popup/popup.ts',
+      content: './src/content/content.ts',
+    },
+    output: {
+      path: outDir,
+      filename: '[name].bundle.js',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: 'ts-loader',
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+            },
           },
         },
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif)$/i,
-        type: 'asset/resource',
-      },
-    ],
-  },
-  resolve: {
-    extensions: ['.ts', '.js'],
-  },
-  plugins: [
-    new CopyWebpackPlugin({
-      patterns: [
-        { from: 'src/manifest.json', to: 'manifest.json' },
-        { from: 'src/popup.html', to: 'popup.html' },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif)$/i,
+          type: 'asset/resource',
+        },
       ],
-    }),
-  ],
-  devtool: 'source-map',
+    },
+    resolve: {
+      extensions: ['.ts', '.js'],
+    },
+    plugins: [
+      new CopyWebpackPlugin({
+        patterns: [
+          { from: manifestSrc, to: 'manifest.json' },
+          { from: 'src/popup.html', to: 'popup.html' },
+        ],
+      }),
+    ],
+    devtool: 'source-map',
+  };
 };


### PR DESCRIPTION
## Summary

- Adds Firefox Manifest V3 support alongside existing Chrome support
- Unifies browser API calls through `webextension-polyfill` (`browser.*` instead of `chrome.*`)
- Firefox manifest uses `background.scripts` instead of `service_worker` (compatible from Firefox 109+)
- Webpack build now targets both browsers: `dist/chrome/` and `dist/firefox/`
- Redesigns popup UI with a flat color palette (no gradients), score-driven badge colors, and cleaned-up labels

## Changes

- `src/shared/browser.ts` — new polyfill re-export shim
- `src/manifest.firefox.json` — Firefox MV3 manifest with gecko settings
- `src/manifest.chrome.json` — renamed from `src/manifest.json`
- `src/background/background.ts`, `src/content/content.ts`, `src/popup/popup.ts` — migrated to `browser.*`
- `webpack.config.js` — env-driven multi-browser build
- `package.json` — new `build:chrome`, `build:firefox`, `dev:firefox` scripts
- `src/popup.html` — flat color palette, fixed badge spacing, score-driven colors
- `tests/__mocks__/webextension-polyfill.ts` — polyfill mock for Jest
- `jest.config.ts` — `moduleNameMapper` for polyfill mock
- `.claude/settings.json` — project hooks (TypeScript check, dist/ guard)

## Test plan

- [x] `npm test` passes with coverage above 80% thresholds
- [x] `npm run lint` passes with no errors
- [x] `npm run build` produces both `dist/chrome/` and `dist/firefox/`
- [x] Extension loads in Chrome via `chrome://extensions` → Load unpacked → `dist/chrome/`
- [x] Extension loads in Firefox via `about:debugging` → Load Temporary Add-on → `dist/firefox/manifest.json`
- [x] Popup UI shows flat colors with score-driven badge colors (green/blue/amber/red)