### PR TITLE
docs: document the library entry point, and fix two things it revealed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,21 @@ jobs:
       - name: Build
         run: npm run build
 
-      # dist/lib/wqa.js is committed so consumers can depend on this repo as a git dependency
-      # without running a build. A committed artifact drifts from its source the first time
-      # someone edits an analyzer and forgets to rebuild — and a stale bundle fails silently,
-      # since consumers would keep asserting against the old logic. The build above regenerates
-      # it, so any difference here means the commit is out of date.
-      - name: Verify the committed library bundle is up to date
+      # dist/lib/ (the bundle and its .d.ts files) is committed so consumers can depend on this
+      # repo as a git dependency without running a build. A committed artifact drifts from its
+      # source the first time someone edits an analyzer and forgets to rebuild — and it fails
+      # silently, since consumers keep asserting against the old logic. The build above
+      # regenerates the whole directory, so any difference means the commit is out of date.
+      #
+      # --exit-code covers modified files; the untracked check catches a newly emitted file
+      # that was never added, which `git diff` alone would not see.
+      - name: Verify the committed library artifacts are up to date
         run: |
-          if ! git diff --quiet -- dist/lib/wqa.js; then
-            echo "::error::dist/lib/wqa.js is stale. Run 'npm run build:lib' and commit the result."
-            git diff --stat -- dist/lib/wqa.js
+          untracked=$(git ls-files --others --exclude-standard -- dist/lib)
+          if [ -n "$untracked" ] || ! git diff --quiet -- dist/lib; then
+            echo "::error::dist/lib is stale. Run 'npm run build:lib' and commit the result."
+            git diff --stat -- dist/lib
+            [ -n "$untracked" ] && echo "untracked:" && echo "$untracked"
             exit 1
           fi
-          echo "dist/lib/wqa.js matches its source."
+          echo "dist/lib matches its source."

--- a/.gitignore
+++ b/.gitignore
@@ -90,8 +90,6 @@ out
 # Negation needs the directory opened first — git will not descend into an ignored dir.
 dist/*
 !dist/lib/
-dist/lib/*
-!dist/lib/wqa.js
 
 # Gatsby files
 .cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,11 @@ Always ignore files in the .gitignore file unless specifically asked to read the
 ## Commands
 
 ```bash
-npm run build          # Compile TypeScript and bundle for both browsers → dist/chrome/ and dist/firefox/
-npm run build:chrome   # Chrome only
-npm run build:firefox  # Firefox only
+npm run build          # All bundles: Chrome, Firefox, and the library
+npm run build:chrome   # Chrome only      → dist/chrome/
+npm run build:firefox  # Firefox only     → dist/firefox/
+npm run build:lib      # Library only     → dist/lib/ (webpack bundle + tsc .d.ts)
+npm run build:types    # Declarations only (tsconfig.lib.json)
 npm run dev            # Watch mode (Chrome)
 npm run dev:firefox    # Watch mode (Firefox)
 npm test               # Run Jest test suite
@@ -27,21 +29,23 @@ npx jest tests/unit/content.core.test.ts
 
 ## Architecture
 
-WebQualityAnalyzer is a **Chrome and Firefox Manifest V3 browser extension** with three isolated execution contexts, each compiled to a separate Webpack bundle:
+WebQualityAnalyzer ships **two products from one source tree**: a Chrome and Firefox Manifest V3 browser extension (three isolated execution contexts) and an injectable library. Each is a separate Webpack bundle:
 
 | Script                         | Bundle                 | Role                                                         |
 | ------------------------------ | ---------------------- | ------------------------------------------------------------ |
 | `src/background/background.ts` | `background.bundle.js` | Extension lifecycle events                                   |
-| `src/content/content.ts`       | `content.bundle.js`    | Content script — orchestrates analysis and registers message listener |
+| `src/content/content.ts`       | `content.bundle.js`    | Content script — registers the message listener, delegates to `analyze.ts` |
+| `src/index.ts`                 | `dist/lib/wqa.js`      | **Library entry** — same analyzers, no extension dependency  |
 | `src/popup/popup.ts`           | `popup.bundle.js`      | Popup UI — sends messages to content script, renders results |
-| `src/shared/browser.ts`        | (imported by all)      | Re-exports `webextension-polyfill` as `browser.*`            |
+| `src/shared/browser.ts`        | (extension bundles)    | Re-exports `webextension-polyfill` as `browser.*`. **Not in the library bundle** |
 | `src/shared/settings.ts`       | (imported by all)      | `AnalyzerSettings` interfaces, `DEFAULT_SETTINGS`, `STORAGE_KEY` |
 
 ### Content module layout
 
 `src/content/` is split into focused modules:
 
-- `content.ts` — thin orchestrator: registers `onMessage` listener, calls analyzers, re-exports types
+- `content.ts` — thin orchestrator: registers `onMessage` listener, delegates to `analyze.ts`, re-exports types
+- `analyze.ts` — `performQualityAnalysis`: runs the enabled analyzers and folds the scores. **Deliberately separate from `content.ts`**, which registers a `browser.runtime.onMessage` listener at module scope — importing that outside the extension drags in `webextension-polyfill` and fires the side effect. Keeping the analysis here is what lets `src/index.ts` expose it to any caller with a DOM
 - `types.ts` — `AnalysisResult`, `CategoryResult`, `Issue` interface definitions
 - `utils.ts` — `getCssSelector` and `getHtmlSnippet` DOM helpers used by analyzers
 - `analyzers/accessibility.ts` — missing alt text, unlabelled inputs, heading hierarchy
@@ -104,12 +108,30 @@ export interface Issue {
 
 Other bundles consume them with zero runtime cost via `import type { AnalysisResult, CategoryResult } from '../content/content'` — types are erased before bundling.
 
+### Library entry point (`src/index.ts`)
+
+The analyzers depend on nothing but `document` and `window.location`, so the extension is one consumer of them rather than their owner. `src/index.ts` exposes them to anything else with a DOM — a Playwright/Cypress spec, a CI script, a console session.
+
+Public surface: `analyzePage(overrides?)`, `collectIssues(result)`, `performQualityAnalysis(settings)`, the three analyzers, `getCssSelector`/`getHtmlSnippet`, `DEFAULT_SETTINGS`, and all types.
+
+- `analyzePage` merges a **partial** override per category over `DEFAULT_SETTINGS`, so `{ seo: { enabled: false } }` disables SEO without disturbing any other threshold. It must not mutate `DEFAULT_SETTINGS` — there is a test pinning that.
+- A **disabled category scores 100, not 0** (`EMPTY_CATEGORY` in `analyze.ts`). It means "nothing found wrong", not "perfect"; averaging a 0 for a switched-off category would misreport the page.
+
+**When adding an export, update `tsconfig.lib.json`'s `include` if it pulls in a new directory**, or the declaration build will not cover it. `src/content/content.ts` is explicitly excluded there — it would drag `webextension-polyfill` into the library's type graph.
+
 ### Build Output
 
-Webpack accepts `--env browser=chrome|firefox` and outputs to `dist/<browser>/`. The correct manifest (`src/manifest.chrome.json` or `src/manifest.firefox.json`) and `src/popup.html` are copied alongside the bundles.
+Webpack accepts `--env browser=chrome|firefox` and outputs to `dist/<browser>/`. The correct manifest (`src/manifest.chrome.json` or `src/manifest.firefox.json`) and `src/popup.html` are copied alongside the bundles. `--env lib` builds the library instead.
 
 - `dist/chrome/` — load via `chrome://extensions` → Load unpacked
 - `dist/firefox/` — load via `about:debugging` → Load Temporary Add-on → select `manifest.json`
+- `dist/lib/` — **committed to git.** `wqa.js` (webpack) plus `.d.ts` files (tsc via `tsconfig.lib.json`)
+
+`dist/lib/` is the only build output in version control. Consumers install it as a git dependency (`npm i -D github:adrianjiga/WebQualityAnalyzer`), which has no publish step and no build-on-install, so the artifact has to be present in the tree. `.gitignore` uses `dist/*` + `!dist/lib/` — note that a bare `!dist/lib/wqa.js` under a `dist` rule does nothing, because **git will not descend into an ignored directory** to find a negated file.
+
+The library bundle is **not minified** (`mode: 'none'`). It is injected into a local page, never fetched over a network, so bytes are the wrong target; minified output is a single line with no newlines, which makes every diff unreviewable, defeats git's delta compression on a file that is rebuilt constantly, and strips real function names from stack traces.
+
+**After changing any analyzer, `analyze.ts`, `utils.ts`, `shared/settings.ts`, or `index.ts`: run `npm run build:lib` and commit `dist/lib/`.** CI fails otherwise.
 
 ### Browser API
 
@@ -126,10 +148,12 @@ The `onMessage` listener in `content.ts` returns a `Promise` (polyfill pattern) 
 
 ## CI
 
-| Workflow | File                          | Triggers                       | Steps              |
-| -------- | ----------------------------- | ------------------------------ | ------------------ |
-| CI       | `.github/workflows/ci.yml`    | push (all branches), PR → main | lint, build        |
-| Tests    | `.github/workflows/tests.yml` | push (all branches), PR → main | test with coverage |
+| Workflow | File                          | Triggers                       | Steps                                          |
+| -------- | ----------------------------- | ------------------------------ | ---------------------------------------------- |
+| CI       | `.github/workflows/ci.yml`    | push (all branches), PR → main | lint, build, verify committed `dist/lib/`      |
+| Tests    | `.github/workflows/tests.yml` | push (all branches), PR → main | test with coverage                             |
+
+The `dist/lib/` check rebuilds and fails on any difference from the commit. It tests **two** conditions — `git diff` for modified files, and `git ls-files --others` for a newly emitted file that was never added, which `git diff` alone would not catch. A stale committed artifact fails silently otherwise, because consumers keep asserting against the old logic.
 
 Actions are pinned to commit SHAs for supply-chain security. Dependabot is configured to keep them up to date weekly.
 
@@ -140,6 +164,7 @@ Actions are pinned to commit SHAs for supply-chain security. Dependabot is confi
 | File                                       | What it covers                                                                                                      |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
 | `tests/unit/content.core.test.ts`          | `performQualityAnalysis`, `browser.runtime.onMessage` listener, `getCssSelector`, `getHtmlSnippet`                 |
+| `tests/unit/index.test.ts`                 | Library entry — `analyzePage` (defaults, per-category disable, partial-override merge, no `DEFAULT_SETTINGS` mutation) and `collectIssues` (category tagging, empty for a clean page) |
 | `tests/unit/content.accessibility.test.ts` | `analyzeAccessibility` — all accessibility checks                                                                   |
 | `tests/unit/content.seo.test.ts`           | `analyzeSEO` — all SEO checks                                                                                       |
 | `tests/unit/content.performance.test.ts`   | `analyzePerformance` — all performance checks                                                                       |
@@ -152,7 +177,7 @@ Actions are pinned to commit SHAs for supply-chain security. Dependabot is confi
 | `tests/helpers/helpers.ts`                 | Shared DOM helpers for content tests: `appendImg`, `appendInput`, `appendHeading`, `appendMeta`, `appendLink`, `appendH1`, `addImageWithDimensions`, `appendImgs`, `appendSpansWithStyle`, `appendExternalScripts`, `appendExternalLinks`, `appendExternalAnchors` |
 | `tests/helpers/popup.ts`                   | Shared popup fixtures: `buildCategory`, `buildResult`, `setupPopupDOM` (includes all settings DOM elements)         |
 
-Coverage baseline (2026-03): **95.14% stmts / 88.23% branches / 88.33% funcs / 95.56% lines** — all above the 80% global threshold.
+Coverage baseline (2026-08): **95.83% stmts / 89.24% branches / 83.78% funcs / 96.14% lines** — all above the 80% global threshold. The threshold in `jest.config.ts` is the contract; this number is a dated snapshot.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Web Quality Analyzer
 
-A Chrome and Firefox Manifest V3 browser extension that audits web pages for accessibility, SEO, and performance issues and gives an instant quality score.
+Audits web pages for accessibility, SEO, and performance issues and gives an instant quality score.
+
+Ships in two forms from one codebase:
+
+- **A Chrome and Firefox Manifest V3 browser extension** — point it at a page, get a scored report in a popup.
+- **An injectable library** (`dist/lib/wqa.js`) — the same analyzers, callable from a test runner, a CI script, or a browser console. See [Use as a library](#use-as-a-library).
+
+The analyzers are pure DOM logic with no extension coupling, which is what makes the second form possible.
 
 [![CI](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/ci.yml/badge.svg)](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/ci.yml)
 [![Tests](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/tests.yml/badge.svg)](https://github.com/adrianjiga/WebQualityAnalyzer/actions/workflows/tests.yml)
@@ -21,15 +28,18 @@ A Chrome and Firefox Manifest V3 browser extension that audits web pages for acc
 **Prerequisites:** Node.js 20 LTS or later, npm
 
 ```bash
-npm install          # install dependencies
-npm run build        # compile + bundle for both Chrome and Firefox → dist/chrome/ and dist/firefox/
-npm run build:chrome # build Chrome only
-npm run build:firefox # build Firefox only
-npm run dev          # watch mode (Chrome)
-npm run dev:firefox  # watch mode (Firefox)
-npm run lint         # ESLint
-npm test             # Jest test suite (with coverage)
+npm install           # install dependencies
+npm run build         # all three bundles: Chrome, Firefox, and the library
+npm run build:chrome  # Chrome extension only     → dist/chrome/
+npm run build:firefox # Firefox extension only    → dist/firefox/
+npm run build:lib     # injectable library only   → dist/lib/ (bundle + .d.ts)
+npm run dev           # watch mode (Chrome)
+npm run dev:firefox   # watch mode (Firefox)
+npm run lint          # ESLint
+npm test              # Jest test suite (with coverage)
 ```
+
+> **After changing anything under `src/content/analyzers/`, `src/content/analyze.ts`, `src/content/utils.ts`, `src/shared/settings.ts`, or `src/index.ts`, run `npm run build:lib` and commit the result.** `dist/lib/` is committed (see [Use as a library](#use-as-a-library)) and CI fails if it is stale.
 
 ## Loading the extension
 
@@ -47,6 +57,80 @@ npm test             # Jest test suite (with coverage)
 3. Click **Load Temporary Add-on...**
 4. Select `dist/firefox/manifest.json`
 
+## Use as a library
+
+The analyzers touch nothing but `document` and `window.location` — no `browser.*`, no `chrome.*`, no extension lifecycle. The extension is one consumer of them, not their owner, so anything with a live page can run the same audit.
+
+`npm run build:lib` produces two things in `dist/lib/`:
+
+- `wqa.js` — a self-contained IIFE that assigns `globalThis.WebQualityAnalyzer`
+- `*.d.ts` — type declarations, so a TypeScript consumer can type the result without depending on the bundle at runtime
+
+### Install
+
+```bash
+npm i -D github:adrianjiga/WebQualityAnalyzer
+```
+
+The bundle is **committed to the repository**, so a git dependency works with no build step on install.
+
+### Playwright
+
+```js
+await page.addScriptTag({ path: require.resolve('webqualityanalyzer/wqa.js') });
+
+const result = await page.evaluate(() => WebQualityAnalyzer.analyzePage());
+expect(result.categories.accessibility.issues).toEqual([]);
+```
+
+### Cypress
+
+```js
+cy.readFile('node_modules/webqualityanalyzer/dist/lib/wqa.js').then((src) => {
+  cy.window().then((win) => {
+    win.eval(src);
+    const result = win.WebQualityAnalyzer.analyzePage();
+    expect(result.categories.accessibility.issues).to.be.empty;
+  });
+});
+```
+
+### API
+
+| Export | Description |
+|---|---|
+| `analyzePage(overrides?)` | Runs the enabled analyzers against the current page, returns an `AnalysisResult`. |
+| `collectIssues(result)` | Flattens issues across all categories, tagging each with the category it came from. |
+| `performQualityAnalysis(settings)` | Lower level — takes a complete `AnalyzerSettings` rather than a partial override. |
+| `analyzeAccessibility` / `analyzeSEO` / `analyzePerformance` | Individual analyzers, each returning a `CategoryResult`. |
+| `getCssSelector(el)` / `getHtmlSnippet(el)` | DOM helpers used to locate offending elements. |
+| `DEFAULT_SETTINGS` | Every default threshold. |
+
+Every scoring threshold is data, not a constant, so a caller can tighten or relax the rules without forking the analyzers. Overrides merge **per category** over `DEFAULT_SETTINGS`:
+
+```js
+// accessibility only — SEO and performance report a score of 100 and no issues
+const a11y = WebQualityAnalyzer.analyzePage({
+  seo: { enabled: false },
+  performance: { enabled: false },
+});
+
+// stricter alt-text penalty; every other accessibility threshold keeps its default
+const strict = WebQualityAnalyzer.analyzePage({
+  accessibility: { missingAltDeduction: 20 },
+});
+```
+
+A **disabled category scores 100, not 0** — "nothing found wrong", not "perfect". Averaging a 0 for a category the caller switched off would misreport the page.
+
+### Why the bundle is committed
+
+Consumers depend on this repo as a git dependency, which has no publish step and no build-on-install, so the artifact has to be present in the tree.
+
+A build output in git goes stale the moment someone edits an analyzer and forgets to rebuild — and it fails *silently*, because consumers keep asserting against the old logic. CI therefore rebuilds on every push and fails if anything in `dist/lib/` differs from the commit, including a newly emitted file that was never added.
+
+The bundle is deliberately **not minified**. It is injected into a local page rather than fetched over a network, so bytes are the wrong thing to optimise; a minified bundle is a single line with no newlines, which makes every diff unreviewable and defeats git's delta compression. Readable output also keeps real function names in stack traces.
+
 ## Running tests
 
 ```bash
@@ -56,22 +140,26 @@ npx jest tests/unit/content.core.test.ts  # single file
 ```
 
 Coverage thresholds (all enforced): **80% statements, branches, functions, and lines**.
-Current baseline: 95.14% stmts / 88.23% branches / 88.33% funcs / 95.56% lines.
+Baseline as of 2026-08: 95.83% stmts / 89.24% branches / 83.78% funcs / 96.14% lines.
+The threshold is the contract — the baseline is a dated snapshot and will drift; `jest.config.ts` is the source of truth.
 
 ## Architecture
 
-The extension has three isolated execution contexts, each compiled to a separate Webpack bundle, plus a shared browser API abstraction:
+Four Webpack bundles from one source tree — three extension contexts plus the library:
 
 | Source | Bundle | Role |
 |--------|--------|------|
 | `src/background/background.ts` | `background.bundle.js` | Extension lifecycle events |
-| `src/content/content.ts` | `content.bundle.js` | Orchestrates analysis, registers message listener |
+| `src/content/content.ts` | `content.bundle.js` | Registers the message listener, delegates to `analyze.ts` |
 | `src/popup/popup.ts` | `popup.bundle.js` | Popup UI — sends messages to content script, renders results |
-| `src/shared/browser.ts` | (imported by all) | Re-exports `webextension-polyfill` for unified `browser.*` API |
+| `src/index.ts` | `dist/lib/wqa.js` | Library entry — the same analyzers, no extension dependency |
+| `src/shared/browser.ts` | (imported by extension bundles) | Re-exports `webextension-polyfill` for unified `browser.*` API |
 
 **Communication flow:** Popup → `browser.tabs.sendMessage` → Content Script → `AnalysisResult` → Popup renders
 
-`src/content/` is split into focused modules: `types.ts` (interfaces), `utils.ts` (`getCssSelector`, `getHtmlSnippet`), and `analyzers/` (one file per category). `src/popup/` is split into `popup.ts`, `popup.css`, `utils.ts`, and `settings.ts` (storage load/save/reset). `src/shared/` holds `browser.ts` and `settings.ts` (shared types and defaults used by both popup and content bundles).
+`src/content/` is split into focused modules: `analyze.ts` (`performQualityAnalysis`), `types.ts` (interfaces), `utils.ts` (`getCssSelector`, `getHtmlSnippet`), and `analyzers/` (one file per category). `src/popup/` is split into `popup.ts`, `popup.css`, `utils.ts`, and `settings.ts` (storage load/save/reset). `src/shared/` holds `browser.ts` and `settings.ts` (shared types and defaults used by both popup and content bundles).
+
+**`analyze.ts` is separate from `content.ts` on purpose.** `content.ts` registers a `browser.runtime.onMessage` listener at module scope, so importing it drags in `webextension-polyfill` and fires that side effect. Keeping the analysis in its own module is what lets `src/index.ts` expose it to callers that have a DOM but no extension. `content.ts` re-exports `performQualityAnalysis`, so existing importers are unaffected.
 
 Shared types (`AnalysisResult`, `CategoryResult`, `Issue`) are defined in `src/content/types.ts`, re-exported from `content.ts`, and consumed via `import type` in `popup.ts` — erased before bundling, zero runtime overhead.
 
@@ -88,7 +176,9 @@ Webpack selects the correct manifest via `--env browser=chrome|firefox` and writ
 
 | Workflow | Triggers | Steps |
 |----------|----------|-------|
-| CI | push (all branches), PR → main | lint, build |
+| CI | push (all branches), PR → main | lint, build, verify the committed library bundle is current |
 | Tests | push (all branches), PR → main | Jest with coverage |
+
+The bundle check rebuilds `dist/lib/` and fails if anything differs from the commit — modified files *or* a newly emitted file that was never added — so a committed artifact can never silently drift from the source it was built from.
 
 All GitHub Actions are pinned to commit SHAs. Dependabot keeps them up to date weekly.

--- a/dist/lib/content/analyze.d.ts
+++ b/dist/lib/content/analyze.d.ts
@@ -1,0 +1,17 @@
+import type { AnalysisResult } from './types';
+import { AnalyzerSettings } from '../shared/settings';
+/**
+ * Runs every enabled analyzer against the current `document` and folds the three category
+ * results into one overall score.
+ *
+ * This lives apart from `content.ts` deliberately. `content.ts` registers a
+ * `browser.runtime.onMessage` listener at module scope, so importing it outside the extension
+ * drags in `webextension-polyfill` and fires that side effect. The analysis itself needs
+ * nothing but a DOM — keeping it in its own module is what lets the library entry
+ * (`src/index.ts`) expose it to any caller with a page: a test runner, a CI script, a
+ * headless browser.
+ *
+ * A disabled category scores 100 rather than 0 — it is "nothing found wrong", not "perfect",
+ * and averaging a 0 for a category the caller switched off would misreport the page.
+ */
+export declare function performQualityAnalysis(settings?: AnalyzerSettings): AnalysisResult;

--- a/dist/lib/content/analyzers/accessibility.d.ts
+++ b/dist/lib/content/analyzers/accessibility.d.ts
@@ -1,0 +1,3 @@
+import type { CategoryResult } from '../types';
+import { AccessibilitySettings } from '../../shared/settings';
+export declare function analyzeAccessibility(settings?: AccessibilitySettings): CategoryResult;

--- a/dist/lib/content/analyzers/performance.d.ts
+++ b/dist/lib/content/analyzers/performance.d.ts
@@ -1,0 +1,3 @@
+import type { CategoryResult } from '../types';
+import { PerformanceSettings } from '../../shared/settings';
+export declare function analyzePerformance(settings?: PerformanceSettings): CategoryResult;

--- a/dist/lib/content/analyzers/seo.d.ts
+++ b/dist/lib/content/analyzers/seo.d.ts
@@ -1,0 +1,3 @@
+import type { CategoryResult } from '../types';
+import { SeoSettings } from '../../shared/settings';
+export declare function analyzeSEO(settings?: SeoSettings): CategoryResult;

--- a/dist/lib/content/types.d.ts
+++ b/dist/lib/content/types.d.ts
@@ -1,0 +1,25 @@
+export interface AnalysisResult {
+    score: number;
+    pageInfo: {
+        url: string;
+        title: string;
+        timestamp: string;
+    };
+    categories: {
+        accessibility: CategoryResult;
+        seo: CategoryResult;
+        performance: CategoryResult;
+    };
+}
+export interface CategoryResult {
+    score: number;
+    issues: Issue[];
+    suggestions: string[];
+}
+export interface Issue {
+    type: string;
+    message: string;
+    severity: 'high' | 'medium' | 'low';
+    selector?: string;
+    htmlSnippet?: string;
+}

--- a/dist/lib/content/utils.d.ts
+++ b/dist/lib/content/utils.d.ts
@@ -1,0 +1,2 @@
+export declare function getCssSelector(el: Element): string;
+export declare function getHtmlSnippet(el: Element, maxLength?: number): string;

--- a/dist/lib/index.d.ts
+++ b/dist/lib/index.d.ts
@@ -1,0 +1,55 @@
+/**
+ * Library entry point.
+ *
+ * The browser extension is one consumer of these analyzers, not their owner. Everything below
+ * is pure DOM logic — no `browser.*`, no `chrome.*`, no extension lifecycle — so anything with
+ * a live page can run it: a Playwright or Cypress spec, a headless-browser CI script, a
+ * scratch console session.
+ *
+ * Bundled by `npm run build:lib` into `dist/lib/wqa.js` as a self-contained IIFE that assigns
+ * `globalThis.WebQualityAnalyzer`. A test runner injects that file into a page and calls
+ * `WebQualityAnalyzer.analyzePage()`.
+ */
+export { performQualityAnalysis } from './content/analyze';
+export { analyzeAccessibility } from './content/analyzers/accessibility';
+export { analyzeSEO } from './content/analyzers/seo';
+export { analyzePerformance } from './content/analyzers/performance';
+export { getCssSelector, getHtmlSnippet } from './content/utils';
+export type { AnalysisResult, CategoryResult, Issue } from './content/types';
+export type { AnalyzerSettings, AccessibilitySettings, SeoSettings, PerformanceSettings, } from './shared/settings';
+export { DEFAULT_SETTINGS } from './shared/settings';
+import type { AnalysisResult } from './content/types';
+import { AnalyzerSettings } from './shared/settings';
+/** A partial settings override, merged over {@link DEFAULT_SETTINGS} one level deep. */
+export type SettingsOverride = {
+    [K in keyof AnalyzerSettings]?: Partial<AnalyzerSettings[K]>;
+};
+/**
+ * Analyses the current page.
+ *
+ * The thresholds every check scores against are data, not constants, so a caller can tighten
+ * or relax them without forking the analyzers. Overrides are merged per category over
+ * {@link DEFAULT_SETTINGS}, so `{ seo: { enabled: false } }` disables SEO while leaving every
+ * accessibility and performance threshold untouched.
+ *
+ * @example
+ * // everything, default thresholds
+ * const result = analyzePage();
+ *
+ * @example
+ * // accessibility only
+ * const a11y = analyzePage({
+ *   seo: { enabled: false },
+ *   performance: { enabled: false },
+ * });
+ */
+export declare function analyzePage(overrides?: SettingsOverride): AnalysisResult;
+/**
+ * Every issue found, flattened across categories and tagged with the category it came from.
+ *
+ * Assertions usually care about "which problems exist on this page", not the per-category
+ * split — this saves every caller writing the same `Object.entries(...).flatMap(...)`.
+ */
+export declare function collectIssues(result: AnalysisResult): Array<AnalysisResult['categories'][keyof AnalysisResult['categories']]['issues'][number] & {
+    category: keyof AnalysisResult['categories'];
+}>;

--- a/dist/lib/shared/settings.d.ts
+++ b/dist/lib/shared/settings.d.ts
@@ -1,0 +1,33 @@
+export interface AccessibilitySettings {
+    enabled: boolean;
+    missingAltDeduction: number;
+    missingAltCap: number;
+    unlabelledInputDeduction: number;
+    unlabelledInputCap: number;
+    headingHierarchyDeduction: number;
+}
+export interface SeoSettings {
+    enabled: boolean;
+    titleMinLength: number;
+    titleMaxLength: number;
+    metaDescMinLength: number;
+    metaDescMaxLength: number;
+    noH1Deduction: number;
+    multipleH1Deduction: number;
+}
+export interface PerformanceSettings {
+    enabled: boolean;
+    imageMaxWidth: number;
+    imageMaxHeight: number;
+    lazyLoadThreshold: number;
+    externalResourcesThreshold: number;
+    inlineStylesThreshold: number;
+    externalLinksDeductionCap: number;
+}
+export interface AnalyzerSettings {
+    accessibility: AccessibilitySettings;
+    seo: SeoSettings;
+    performance: PerformanceSettings;
+}
+export declare const STORAGE_KEY = "analyzerSettings";
+export declare const DEFAULT_SETTINGS: AnalyzerSettings;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Web quality analysis browser extension for developers and QA professionals",
   "scripts": {
-    "build": "webpack --env browser=chrome && webpack --env browser=firefox && webpack --env lib",
+    "build": "webpack --env browser=chrome && webpack --env browser=firefox && npm run build:lib",
     "build:chrome": "webpack --env browser=chrome",
     "build:firefox": "webpack --env browser=firefox",
     "dev": "webpack --watch --env browser=chrome",
@@ -13,7 +13,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "lint": "eslint src tests",
-    "build:lib": "webpack --env lib"
+    "build:lib": "webpack --env lib && npm run build:types",
+    "build:types": "tsc -p tsconfig.lib.json"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "dist/lib",
+    "rootDir": "src"
+  },
+  "include": ["src/index.ts", "src/content/**/*", "src/shared/settings.ts"],
+  "exclude": ["src/content/content.ts"]
+}


### PR DESCRIPTION
Brings `README.md` and `CLAUDE.md` up to date with #148 and #149. Writing them surfaced two real defects, both fixed here.

## Two bugs the docs found

**1. `package.json` declared a `types` path that was never built.** #148 set `types: "dist/lib/index.d.ts"`, but nothing emitted declarations — webpack with `ts-loader` doesn't, and there was no `tsc` step. A TypeScript consumer following the install instructions would have got a broken types resolution.

Fixed by adding `tsconfig.lib.json` (`emitDeclarationOnly`) and a `build:types` step chained into `build:lib`. Verified a consumer can now `import type { AnalysisResult, Issue }` and that `Issue['severity']` correctly rejects an invalid member.

`src/content/content.ts` is explicitly excluded from that tsconfig — including it would drag `webextension-polyfill` into the library's type graph, undoing the separation #148 established.

**2. The README's install instructions used the wrong package name.** I wrote `web-quality-analyzer`; the package is `webqualityanalyzer`. `require.resolve('web-quality-analyzer/wqa.js')` would simply have thrown. Both the Playwright and Cypress snippets are corrected and checked against `package.json`'s `name` and `exports` map.

## Also fixed

The CI staleness check from #148 only guarded `dist/lib/wqa.js`. Now that the directory holds `.d.ts` files too, it covers all of `dist/lib` — and tests **two** conditions, because `git diff` alone misses a newly emitted file that was never added:

```bash
untracked=$(git ls-files --others --exclude-standard -- dist/lib)
if [ -n "$untracked" ] || ! git diff --quiet -- dist/lib; then ...
```

Verified by adding an export, rebuilding, and confirming the check fires.

`.gitignore` also got simpler — `dist/*` + `!dist/lib/`. My first attempt tried to negate individual files under an ignored `dist`, which silently does nothing: **git will not descend into an ignored directory to find a negated file.** I hit that twice, so it is now written down in `CLAUDE.md` rather than left as a trap.

## Documentation

**README** — reframed as two products from one codebase rather than "a browser extension". New *Use as a library* section: install, Playwright and Cypress snippets, the full export table, the per-category override semantics, and why the bundle is committed and unminified. The disabled-category rule is stated explicitly (a disabled category scores **100**, not 0 — "nothing found wrong", not "perfect").

**CLAUDE.md** — `analyze.ts` and `src/index.ts` added to the module layout with the reason they are separate; a *Library entry point* section covering the override merge and the `tsconfig.lib.json` `include` trap when adding exports; build output now records that `dist/lib/` is the only build artifact in version control; CI and test tables updated.

Both coverage baselines were stale (`95.14 / 88.23 / 88.33 / 95.56`, undated in the README and marked 2026-03 in CLAUDE.md). Re-measured: **95.83 / 89.24 / 83.78 / 96.14**, now dated in both, with a note that `jest.config.ts` holds the contract and the number is only a snapshot.

## Verified

Every script, file path, and export named in the docs was checked to exist. `package.json`'s `exports` map resolves to real files. 239 tests pass, lint clean, and `dist/lib` rebuilds byte-identical.