### PR TITLE
docs(readme): link the cross-repo architecture notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Audits web pages for accessibility, SEO, and performance issues and gives an instant quality score.
 
+> **Architecture** — this repository is one of six that behave as a single system.
+> The [cross-repo architecture notes](https://adrianjiga.github.io/qa/architecture)
+> cover the `data-cy` contract, the coordinated-deploy problem, and the known gaps.
+
 Ships in two forms from one codebase:
 
 - **A Chrome and Firefox Manifest V3 browser extension** — point it at a page, get a scored report in a popup.


### PR DESCRIPTION
Points at the new [architecture page](https://adrianjiga.github.io/qa/architecture) (adrianjiga.github.io#21) rather than restating any of it here.

The page covers the `data-cy` contract these suites depend on, why a two-sided contract across repositories cannot be changed atomically, and the known gaps. Keeping it in one place is the same rule the rest of this portfolio now enforces: a fact that lives in two places diverges.

Merge after adrianjiga.github.io#21, or the link 404s until Pages deploys.